### PR TITLE
Update spacy_symspell.py

### DIFF
--- a/spacy_symspell/spacy_symspell.py
+++ b/spacy_symspell/spacy_symspell.py
@@ -55,8 +55,10 @@ class SpellingCorrector(object):
 
     def __call__(self, spacy_object):
         assert isinstance(spacy_object, Doc) or isinstance(spacy_object, Span), "spacy_object must be a spacy Doc or Span object but it is a {}".format(type(spacy_object))
-        spacy_object.set_extension("suggestions", getter=_get_suggestions)
-        spacy_object.set_extension("segmentation", getter=_get_segmentation)
+        if spacy_object.get_extension("suggestions") is None:
+            spacy_object.set_extension("suggestions", getter=_get_suggestions)
+        if spacy_object.get_extension("segmentation") is None:
+            spacy_object.set_extension("segmentation", getter=_get_segmentation)
         for sent in spacy_object.sents:
             if sent.get_extension("suggestions") is None:
                 sent.set_extension("suggestions", getter=_get_suggestions)


### PR DESCRIPTION
Check whether extensions are already loaded before adding them.

The following code raises an exception due to the attempt to add already existing extensions.

```python
import spacy
from spacy_symspell import SpellingCorrector

nlp = spacy.load("en")
corrector = SpellingCorrector()
nlp.add_pipe(corrector)
doc = nlp("What's updoc")

for s in doc._.suggestions:
    print(s)

doc = nlp("Thetea isready")
for s in doc._.suggestions:
    print(s)
```

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-55b39d71d94b> in <module>
      5 corrector = SpellingCorrector()
      6 nlp.add_pipe(corrector)
----> 7 doc = nlp("What's updoc")
      8 
      9 for s in doc._.suggestions:

/mnt/data/amignon/Projets/Sandbox/nlp/venv/lib/python3.6/site-packages/spacy/language.py in __call__(self, text, disable, component_cfg)
    383             if not hasattr(proc, "__call__"):
    384                 raise ValueError(Errors.E003.format(component=type(proc), name=name))
--> 385             doc = proc(doc, **component_cfg.get(name, {}))
    386             if doc is None:
    387                 raise ValueError(Errors.E005.format(name=name))

/mnt/data/amignon/Projets/Sandbox/nlp/spacy_symspell/spacy_symspell/spacy_symspell.py in __call__(self, spacy_object)
     56     def __call__(self, spacy_object):
     57         assert isinstance(spacy_object, Doc) or isinstance(spacy_object, Span), "spacy_object must be a spacy Doc or Span object but it is a {}".format(type(spacy_object))
---> 58         spacy_object.set_extension("suggestions", getter=_get_suggestions)
     59         spacy_object.set_extension("segmentation", getter=_get_segmentation)
     60         for sent in spacy_object.sents:

doc.pyx in spacy.tokens.doc.Doc.set_extension()

ValueError: [E090] Extension 'suggestions' already exists on Doc. To overwrite the existing extension, set `force=True` on `Doc.set_extension`.
```

So I have added a check before trying to add extensions.